### PR TITLE
fix: 안쓰는 임포트 주석처리 및 호환이 안되던 google-genai 패키지 변경

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ packaging==24.2
 python-dotenv==1.1.0
 Werkzeug==3.1.3
 mysql-connector-python==9.3.0
-google-genai==1.11.0
+google-genai==1.13.0
 pytz==2024.1
 flasgger==0.9.7.1
 alembic==1.13.0
@@ -21,3 +21,5 @@ neo4j-graphrag==1.6.1
 neomodel==5.0.0
 sentence-transformers==4.1.0
 numpy==1.24.4
+langchain==0.3.25
+langchain_community==0.3.16

--- a/src/app/services/PromptService.py
+++ b/src/app/services/PromptService.py
@@ -9,7 +9,7 @@ from ..repositories.neo4j.MemberRepository import Neo4jMemberRepository
 from ..repositories.neo4j.ProductRepository import Neo4jProductRepository
 
 from ..utils.gemini import  post_gemini
-from ..utils.text_embedding import CustomE5Embedding, get_text_embedding
+from ..utils.text_embedding import get_text_embedding
 from ..utils import db, ts
 
 from ..models.chatMessage import AuthorType  # ✅ 모델 가져오기


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 패키지 수정 및 안쓰는 import 삭제하였습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)
- import 에러 (주석처리했는데 불러와서 생김)
```
|   File "/app/src/app/services/__init__.py", line 2, in <module>
web-1  |     from .PromptService import PromptService
web-1  |   File "/app/src/app/services/PromptService.py", line 12, in <module>
web-1  |     from ..utils.text_embedding import CustomE5Embedding, get_text_embedding
web-1  | ImportError: cannot import name 'CustomE5Embedding' from 'src.app.utils.text_embedding' (/app/src/app/utils/text_embedding.py)
web-1  | [2025-05-04 11:17:52 +0900] [35] [INFO] Worker exiting (pid: 35)
```

- gen ai 패키지 에러
```
  Downloading google_auth-2.14.1-py2.py3-none-any.whl.metadata (4.2 kB)
web-1  | Collecting fsspec<2025.0.0,>=2024.9.0 (from neo4j-graphrag==1.6.1->-r requirements.txt (line 20))
web-1  |   Downloading fsspec-2024.10.0-py3-none-any.whl.metadata (11 kB)
web-1  | Collecting anyio<5.0.0,>=4.8.0 (from google-genai==1.11.0->-r requirements.txt (line 13))
web-1  |   Downloading anyio-4.8.0-py3-none-any.whl.metadata (4.6 kB)
web-1  | ERROR: Cannot install google-genai because these package versions have conflicting dependencies.
web-1  | 
web-1  | The conflict is caused by:
web-1  |     google-auth 2.39.0 depends on pyasn1-modules>=0.2.1
web-1  |     google-auth 2.38.0 depends on pyasn1-modules>=0.2
```

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
